### PR TITLE
Fix "entrypoint.sh not found"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ VOLUME /srv
 EXPOSE 80
 COPY webdav.conf /etc/nginx/conf.d/default.conf
 
-COPY entrypoint.sh /
-RUN chmod +x entrypoint.sh
-CMD /entrypoint.sh && nginx -g "daemon off;"
+COPY entrypoint.sh /docker-entrypoint.d
+RUN chmod +x /docker-entrypoint.d/entrypoint.sh
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Changes in the based image caused the following error when I build and run the container:
```
/bin/sh: /entrypoint.sh: not found
```
As you can see here https://github.com/nginxinc/docker-nginx/blob/master/stable/alpine/ the `docker-entrypoint.sh` in the base image is intended to run setup scripts, so I moved the `entrypoint.sh` to the `docker-entrypoint.d` and it is properly executed during startup.